### PR TITLE
Add --bind & --volume options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ The [docker export](https://docs.docker.com/engine/reference/commandline/export/
 
 # Usage
 
-`docker-volumes.sh [-v|--verbose] CONTAINER [save|load] TARBALL`
+```
+Usage: docker-volumes.sh [-b|--bind] [-V|--volume] [-v|--verbose] CONTAINER save|load TARBALL
+Options:
+-b, --bind	Use only bind-mounts
+-v, --volume	Use only internal volumes
+-v, --verbose	Be verbose
+-h, --help	Show this help
+```
 
 # Podman
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ docker-volumes.sh $CONTAINER load $CONTAINER-volumes.tar
 docker start $CONTAINER
 ```
 
-# Notes
-* This script could have been written in Python or Go, but the tarfile module and the tar package lack support for writing sparse files.
-* We use the Ubuntu Docker image with GNU tar v1.29+ that uses **SEEK\_DATA**/**SEEK\_HOLE** to [manage sparse files](https://www.gnu.org/software/tar/manual/html_chapter/tar_8.html#SEC137).
-* To see the volumes that would be processed run `docker container inspect -f '{{json .Mounts}}' $CONTAINER` and pipe it to either [`jq`](https://stedolan.github.io/jq/) or `python -m json.tool`.
+## Notes
+- This script could have been written in Python or Go, but the tarfile module and the tar package lack support for writing sparse files.
+- We use the Ubuntu Docker image with GNU tar v1.29+ that uses `SEEK_DATA` & `SEEK_HOLE` to [manage sparse files](https://www.gnu.org/software/tar/manual/html_chapter/tar_8.html#SEC137).
+- To see the volumes that would be processed run `docker container inspect -f '{{json .Mounts}}' $CONTAINER` and pipe it to either [`jq`](https://stedolan.github.io/jq/) or `python -m json.tool`.
 
-# Bugs / Features
-* Make sure the volumes are defined as such with the `VOLUME` directive. For example, the Apache image lacks them, but you can add them manually with `docker commit --change 'VOLUME /usr/local/apache2/htdocs' $CONTAINER $CONTAINER`
+## BUGS / LIMITATIONS
+- The `--volumes-from` option is [buggy in Podman < 4.7.0](https://github.com/containers/podman/issues/19529)
+- Make sure the volumes are defined as such with the `VOLUME` directive. For example, the Apache image lacks them, but you can add them manually with `docker commit --change 'VOLUME /usr/local/apache2/htdocs' $CONTAINER $CONTAINER`

--- a/docker-volumes.sh
+++ b/docker-volumes.sh
@@ -3,13 +3,13 @@
 # The docker-export and docker-commit/docker-save commands do not save the container volumes.
 # Use this script to save and load the container volumes.
 #
-# v1.8 by Ricardo Branco
-#
 # NOTES:
 #  + This script could have been written in Python or Go, but the tarfile module and the tar package
 #    lack support for writing sparse files.
 #  + We use the Ubuntu docker image with tar v1.29+ that uses SEEK_DATA/SEEK_HOLE to manage sparse files.
 #
+
+VERSION="2.0"
 
 # Set DOCKER=podman if you want to use podman instead of docker
 DOCKER="${DOCKER:-docker}"
@@ -30,6 +30,7 @@ show_usage() {
 			-b, --bind	Use only bind-mounts
 			-V, --volume	Use only internal volumes
 			-v, --verbose	Be verbose
+			--version	Print version and exit
 			-h, --help	Show this help
 	EOF
 }
@@ -48,6 +49,9 @@ while [[ $# -gt 0 ]]; do
 			shift ;;
 		-h|--help)
 			show_usage
+			exit 0 ;;
+		--version)
+			echo "$VERSION"
 			exit 0 ;;
 		-*)
 			echo "Invalid option: $1" >&2

--- a/docker-volumes.sh
+++ b/docker-volumes.sh
@@ -11,24 +11,60 @@
 #  + We use the Ubuntu docker image with tar v1.29+ that uses SEEK_DATA/SEEK_HOLE to manage sparse files.
 #
 
+# Set DOCKER=podman if you want to use podman instead of docker
+DOCKER="${DOCKER:-docker}"
+
+IMAGE="${IMAGE:-ubuntu:24.04}"
+
+# We use .Destination since we're using --volumes-from
+FILTER_BOTH='{{ range .Mounts }}{{ printf "%v\x00" .Destination }}{{ end }}'
+FILTER_BIND='{{ range .Mounts }}{{ if eq .Type "bind" }}{{ printf "%v\x00" .Destination }}{{ end }}'
+FILTER_VOLUME='{{ range .Mounts }}{{ if eq .Type "volume" }}{{ printf "%v\x00" .Destination }}{{ end }}'
+
+FILTER="$FILTER_BOTH"
+
+show_usage() {
+	cat <<-EOF
+		Usage: $0 [-b|--bind] [-V|--volume] [-v|--verbose] CONTAINER save|load TARBALL
+		Options:
+			-b, --bind	Use only bind-mounts
+			-V, --volume	Use only internal volumes
+			-v, --verbose	Be verbose
+			-h, --help	Show this help
+	EOF
+}
+
 verbose=""
-if [[ $1 == "-v" || $1 == "--verbose" ]] ; then
-	verbose="-v"
-	shift
-fi
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-b|--bind)
+			FILTER="$FILTER_BIND"
+			shift ;;
+		-V|--volume)
+			FILTER="$FILTER_VOLUME"
+			shift ;;
+		-v|--verbose)
+			verbose="-v"
+			shift ;;
+		-h|--help)
+			show_usage
+			exit 0 ;;
+		-*)
+			echo "Invalid option: $1" >&2
+			show_usage >&2
+			exit 1 ;;
+		*)
+			break ;;
+	esac
+done
 
 if [[ $# -ne 3 || ! $2 =~ ^(save|load)$ ]] ; then
 	echo "Usage: $0 [-v|--verbose] CONTAINER [save|load] TARBALL" >&2
 	exit 1
 fi
 
-IMAGE="ubuntu:24.04"
-
-# Set DOCKER=podman if you want to use podman.io instead of docker
-DOCKER=${DOCKER:-"docker"}
-
 get_volumes () {
-	$DOCKER inspect --type container -f '{{range .Mounts}}{{printf "%v\x00" .Destination}}{{end}}' "$CONTAINER" | head -c -1 | sort -uz
+	$DOCKER inspect --type container -f "$FILTER" "$CONTAINER" | head -c -1 | sort -uz
 }
 
 save_volumes () {
@@ -40,7 +76,7 @@ save_volumes () {
 	# Create a void tar file to avoid mounting its directory as a volume
 	touch -- "$TAR_FILE"
 	tmp_dir=$(mktemp -du -p /)
-	get_volumes | $DOCKER run --rm -i --volumes-from "$CONTAINER" -e LC_ALL=C.UTF-8 -v "$TAR_FILE:/${tmp_dir}/${TAR_FILE##*/}" $IMAGE tar -c -a $verbose --null -T- -f "/${tmp_dir}/${TAR_FILE##*/}"
+	get_volumes | $DOCKER run --rm -i --volumes-from "$CONTAINER" -e LC_ALL=C.UTF-8 -v "$TAR_FILE:/${tmp_dir}/${TAR_FILE##*/}" "$IMAGE" tar -c -a $verbose --null -T- -f "/${tmp_dir}/${TAR_FILE##*/}"
 }
 
 load_volumes () {
@@ -49,7 +85,7 @@ load_volumes () {
 		exit 1
 	fi
 	tmp_dir=$(mktemp -du -p /)
-	$DOCKER run --rm --volumes-from "$CONTAINER" -e LC_ALL=C.UTF-8 -v "$TAR_FILE:/${tmp_dir}/${TAR_FILE##*/}":ro $IMAGE tar -xp $verbose -S -f "/${tmp_dir}/${TAR_FILE##*/}" -C / --overwrite
+	$DOCKER run --rm --volumes-from "$CONTAINER" -e LC_ALL=C.UTF-8 -v "$TAR_FILE:/${tmp_dir}/${TAR_FILE##*/}":ro "$IMAGE" tar -xp $verbose -S -f "/${tmp_dir}/${TAR_FILE##*/}" -C / --overwrite
 }
 
 CONTAINER="$1"


### PR DESCRIPTION
This PR:
- Adds `--bind` & `--volume` options
- Updates README with reference to buggy Podman < 4.7.0

Fixes https://github.com/ricardobranco777/docker-volumes.sh/issues/7