### PR TITLE
Fix typo in volume's filter's template

### DIFF
--- a/docker-volumes.sh
+++ b/docker-volumes.sh
@@ -9,7 +9,7 @@
 #  + We use the Ubuntu docker image with tar v1.29+ that uses SEEK_DATA/SEEK_HOLE to manage sparse files.
 #
 
-VERSION="2.0.1"
+VERSION="2.0.2"
 
 # Set DOCKER=podman if you want to use podman instead of docker
 DOCKER="${DOCKER:-docker}"

--- a/docker-volumes.sh
+++ b/docker-volumes.sh
@@ -19,7 +19,7 @@ IMAGE="${IMAGE:-ubuntu:24.04}"
 # We use .Destination since we're using --volumes-from
 FILTER_BOTH='{{ range .Mounts }}{{ printf "%v\x00" .Destination }}{{ end }}'
 FILTER_BIND='{{ range .Mounts }}{{ if eq .Type "bind" }}{{ printf "%v\x00" .Destination }}{{ end }}{{ end }}'
-FILTER_VOLUME='{{ range .Mounts }}{{ if eq .Type "volume" }}{{ printf "%v\x00" .Destination }}{{ end }}{ end }}'
+FILTER_VOLUME='{{ range .Mounts }}{{ if eq .Type "volume" }}{{ printf "%v\x00" .Destination }}{{ end }}{{ end }}'
 
 FILTER="$FILTER_BOTH"
 


### PR DESCRIPTION
First of all, thanks for your script! It's been very helpful at migrating containers and their volumes.

This PR fixes a template issue in volume's filter (when using the --volume option).

Please feel free to edit this PR however you like.